### PR TITLE
feat(discovery): boost search result with table usage

### DIFF
--- a/api/handlers/search_handler.go
+++ b/api/handlers/search_handler.go
@@ -63,6 +63,7 @@ func (handler *SearchHandler) buildSearchCfg(params url.Values) (cfg discovery.S
 	cfg.Text = text
 	cfg.MaxResults, _ = strconv.Atoi(params.Get("size"))
 	cfg.Filters = filterConfigFromValues(params)
+	cfg.SortBy = params.Get("sortby")
 	cfg.TypeWhiteList, err = parseTypeWhiteList(params)
 	return
 }

--- a/api/handlers/search_handler.go
+++ b/api/handlers/search_handler.go
@@ -64,10 +64,6 @@ func (handler *SearchHandler) buildSearchCfg(params url.Values) (cfg discovery.S
 	cfg.MaxResults, _ = strconv.Atoi(params.Get("size"))
 	cfg.Filters = filterConfigFromValues(params)
 	cfg.TypeWhiteList, err = parseTypeWhiteList(params)
-	if err != nil {
-		return
-	}
-
 	return
 }
 

--- a/api/handlers/search_handler.go
+++ b/api/handlers/search_handler.go
@@ -63,7 +63,7 @@ func (handler *SearchHandler) buildSearchCfg(params url.Values) (cfg discovery.S
 	cfg.Text = text
 	cfg.MaxResults, _ = strconv.Atoi(params.Get("size"))
 	cfg.Filters = filterConfigFromValues(params)
-	cfg.SortBy = params.Get("sortby")
+	cfg.RankBy = params.Get("rankby")
 	cfg.TypeWhiteList, err = parseTypeWhiteList(params)
 	return
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/elastic/go-elasticsearch/v7"
+	"github.com/elastic/go-elasticsearch/v7/estransport"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	nrelasticsearch "github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7"
@@ -130,6 +131,12 @@ func initElasticsearch(config Config) *elasticsearch.Client {
 	esClient, err := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: brokers,
 		Transport: nrelasticsearch.NewRoundTripper(nil),
+		//!TODO remove this logger
+		Logger: &estransport.ColorLogger{
+			Output:             os.Stdout,
+			EnableRequestBody:  true,
+			EnableResponseBody: true,
+		},
 	})
 	if err != nil {
 		log.Fatalf("error connecting to elasticsearch: %v", err)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/elastic/go-elasticsearch/v7"
-	"github.com/elastic/go-elasticsearch/v7/estransport"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	nrelasticsearch "github.com/newrelic/go-agent/v3/integrations/nrelasticsearch-v7"
@@ -131,12 +130,6 @@ func initElasticsearch(config Config) *elasticsearch.Client {
 	esClient, err := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses: brokers,
 		Transport: nrelasticsearch.NewRoundTripper(nil),
-		//!TODO remove this logger
-		Logger: &estransport.ColorLogger{
-			Output:             os.Stdout,
-			EnableRequestBody:  true,
-			EnableResponseBody: true,
-		},
 	})
 	if err != nil {
 		log.Fatalf("error connecting to elasticsearch: %v", err)

--- a/discovery/config.go
+++ b/discovery/config.go
@@ -20,4 +20,7 @@ type SearchConfig struct {
 	// List of record types to search for
 	// a zero value signifies that all types should be searched
 	TypeWhiteList []string
+
+	// SortBy is a param to sort based on a specific parameter
+	SortBy string
 }

--- a/discovery/config.go
+++ b/discovery/config.go
@@ -21,6 +21,6 @@ type SearchConfig struct {
 	// a zero value signifies that all types should be searched
 	TypeWhiteList []string
 
-	// SortBy is a param to sort based on a specific parameter
-	SortBy string
+	// RankBy is a param to rank based on a specific parameter
+	RankBy string
 }

--- a/store/elasticsearch/search.go
+++ b/store/elasticsearch/search.go
@@ -130,7 +130,7 @@ func (sr *Searcher) buildQuery(ctx context.Context, cfg discovery.SearchConfig, 
 
 	query := sr.buildFunctionScoreQuery(textQueryWithFilter)
 
-	query = sr.addBoostFieldToSort(cfg.SortBy, query)
+	query = sr.addBoostFieldToSort(cfg.RankBy, query)
 
 	src, err := query.Source()
 	if err != nil {
@@ -145,9 +145,9 @@ func (sr *Searcher) buildQuery(ctx context.Context, cfg discovery.SearchConfig, 
 	return payload, json.NewEncoder(payload).Encode(q)
 }
 
-func (sr *Searcher) addBoostFieldToSort(sortBy string, query *elastic.FunctionScoreQuery) *elastic.FunctionScoreQuery {
-	if sortBy != "" {
-		return query.AddScoreFunc(sr.buildFieldValueFactorQuery(sortBy, "log1p", 1.0, 1.0))
+func (sr *Searcher) addBoostFieldToSort(rankBy string, query *elastic.FunctionScoreQuery) *elastic.FunctionScoreQuery {
+	if rankBy != "" {
+		return query.AddScoreFunc(sr.buildFieldValueFactorQuery(rankBy, "log1p", 1.0, 1.0))
 	}
 	return query
 }

--- a/store/elasticsearch/search.go
+++ b/store/elasticsearch/search.go
@@ -146,9 +146,8 @@ func (sr *Searcher) buildQuery(ctx context.Context, cfg discovery.SearchConfig, 
 }
 
 func (sr *Searcher) addBoostFieldToSort(sortBy string, query *elastic.FunctionScoreQuery) *elastic.FunctionScoreQuery {
-	switch models.ParseSearchSortBy(sortBy) {
-	case models.SearchSortByUsage:
-		return query.AddScoreFunc(sr.buildFieldValueFactorQuery("data.profile.usage_count", "log1p", 1.0, 1.0))
+	if sortBy != "" {
+		return query.AddScoreFunc(sr.buildFieldValueFactorQuery(sortBy, "log1p", 1.0, 1.0))
 	}
 	return query
 }

--- a/store/elasticsearch/search_test.go
+++ b/store/elasticsearch/search_test.go
@@ -157,7 +157,7 @@ func TestSearch(t *testing.T) {
 
 func TestSearchWithUsageBoosting(t *testing.T) {
 	ctx := context.Background()
-	t.Run("should return a descendingly sorted based on usage count in search results if sortby usage in the config", func(t *testing.T) {
+	t.Run("should return a descendingly sorted based on usage count in search results if rank by usage in the config", func(t *testing.T) {
 		esClient := esTestServer.NewClient()
 		testFixture, err := loadTestFixture()
 		if err != nil {
@@ -176,7 +176,7 @@ func TestSearchWithUsageBoosting(t *testing.T) {
 		}
 		searchResults, err := searcher.Search(ctx, discovery.SearchConfig{
 			Text:   "bigquery",
-			SortBy: "data.profile.usage_count",
+			RankBy: "data.profile.usage_count",
 		})
 		expectedOrder := []string{"bigquery::gcpproject/dataset/tablename-common", "bigquery::gcpproject/dataset/tablename-mid", "bigquery::gcpproject/dataset/tablename-1"}
 

--- a/store/elasticsearch/testdata/search-test-fixture.json
+++ b/store/elasticsearch/testdata/search-test-fixture.json
@@ -1,8 +1,6 @@
-[
-    {
+[{
         "type": "topic",
-        "records": [
-            {
+        "records": [{
                 "urn": "order-topic",
                 "name": "order-topic",
                 "service": "kafka",
@@ -61,8 +59,7 @@
     },
     {
         "type": "table",
-        "records": [
-            {
+        "records": [{
                 "urn": "au2-microsoft-invoice",
                 "name": "microsoft-invoice",
                 "service": "postgres",
@@ -76,9 +73,9 @@
                     "description": "Transaction records for every microsoft purchase",
                     "total_rows": 100,
                     "schema": [
-                        {"name": "id"},
-                        {"name": "username", "description": "purchaser username"},
-                        {"name": "item_id", "description": "item identifications"}
+                        { "name": "id" },
+                        { "name": "username", "description": "purchaser username" },
+                        { "name": "item_id", "description": "item identifications" }
                     ]
                 }
             },
@@ -96,12 +93,139 @@
                     "description": "Transaction records for every Apple purchase",
                     "total_rows": 100,
                     "schema": [
-                        {"name": "id"},
-                        {"name": "user_id", "description": "purchaser user idenfitication"},
-                        {"name": "item_id", "description": "item identifications"}
+                        { "name": "id" },
+                        { "name": "user_id", "description": "purchaser user idenfitication" },
+                        { "name": "item_id", "description": "item identifications" }
                     ]
                 }
             }
         ]
+    },
+    {
+        "type": {
+            "name": "table",
+            "classification": "resource"
+        },
+        "records": [{
+            "urn": "bigquery::gcpproject/dataset/tablename-1",
+            "name": "tablename-1",
+            "service": "bigquery",
+            "description": "A sample of table record",
+            "data": {
+                "preview": {},
+                "profile": {
+                    "common_join": [{
+                        "conditions": [
+                            "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
+                        ],
+                        "count": 1,
+                        "urn": "bigquery::gcpproject/dataset/tablename-mid"
+                    }],
+                    "filter_conditions": [
+                        "WHERE t.column_5 = 'success' AND t.item_id = \"280481a2-2384-4b81-aa3e-214ac60b31db\" AND event_timestamp >= TIMESTAMP(\"2021-10-29\", \"UTC\") AND event_timestamp < TIMESTAMP(\"2021-11-22T02:01:06Z\")"
+                    ],
+                    "usage_count": 1
+                },
+                "properties": {
+                    "attributes": {
+                        "dataset": "dataset",
+                        "full_qualified_name": "gcpproject:dataset.tablename-1",
+                        "partition_field": "event_timestamp",
+                        "project": "gcpproject",
+                        "type": "TABLE"
+                    },
+                    "labels": {
+                        "owner": "user_1"
+                    }
+                },
+                "resource": {
+                    "name": "tablename-1",
+                    "service": "bigquery",
+                    "urn": "bigquery::gcpproject/dataset/tablename-1"
+                }
+            }
+        }, {
+            "urn": "bigquery::gcpproject/dataset/tablename-common",
+            "name": "tablename-common",
+            "service": "bigquery",
+            "description": "A sample of table record with high usage",
+            "data": {
+                "preview": {},
+                "profile": {
+                    "common_join": [{
+                        "conditions": [
+                            "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
+                        ],
+                        "count": 1,
+                        "urn": "bigquery::gcpproject/dataset/tablename-mid"
+                    }],
+                    "filter_conditions": [
+                        "WHERE t.column_5 = 'success' AND t.item_id = \"280481a2-2384-4b81-aa3e-214ac60b31db\" AND event_timestamp >= TIMESTAMP(\"2021-10-29\", \"UTC\") AND event_timestamp < TIMESTAMP(\"2021-11-22T02:01:06Z\")"
+                    ],
+                    "usage_count": 10
+                },
+                "properties": {
+                    "attributes": {
+                        "dataset": "dataset",
+                        "full_qualified_name": "gcpproject:dataset.tablename-common",
+                        "partition_field": "event_timestamp",
+                        "project": "gcpproject",
+                        "type": "TABLE"
+                    },
+                    "labels": {
+                        "owner": "user_1"
+                    }
+                },
+                "resource": {
+                    "name": "tablename-common",
+                    "service": "bigquery",
+                    "urn": "bigquery::gcpproject/dataset/tablename-common"
+                }
+            }
+        }, {
+            "urn": "bigquery::gcpproject/dataset/tablename-mid",
+            "name": "tablename-mid",
+            "service": "bigquery",
+            "description": "A sample of table record with mid usage",
+            "data": {
+                "preview": {},
+                "profile": {
+                    "common_join": [{
+                        "conditions": [
+                            "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
+                        ],
+                        "count": 1,
+                        "urn": "bigquery::gcpproject/dataset/tablename-high"
+                    }, {
+                        "conditions": [
+                            "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
+                        ],
+                        "count": 1,
+                        "urn": "bigquery::gcpproject/dataset/tablename-1"
+                    }],
+                    "filter_conditions": [
+                        "WHERE t.column_5 = 'success' AND t.item_id = \"280481a2-2384-4b81-aa3e-214ac60b31db\" AND event_timestamp >= TIMESTAMP(\"2021-10-29\", \"UTC\") AND event_timestamp < TIMESTAMP(\"2021-11-22T02:01:06Z\")"
+                    ],
+                    "usage_count": 5
+                },
+                "properties": {
+                    "attributes": {
+                        "dataset": "dataset",
+                        "full_qualified_name": "gcpproject:dataset.tablename-mid",
+                        "partition_field": "event_timestamp",
+                        "project": "gcpproject",
+                        "type": "TABLE"
+                    },
+                    "labels": {
+                        "owner": "user_1"
+                    }
+                },
+                "resource": {
+                    "name": "tablename-mid",
+                    "service": "bigquery",
+                    "urn": "bigquery::gcpproject/dataset/tablename-mid"
+                }
+            }
+        }]
     }
 ]

--- a/store/elasticsearch/testdata/search-test-fixture.json
+++ b/store/elasticsearch/testdata/search-test-fixture.json
@@ -102,10 +102,7 @@
         ]
     },
     {
-        "type": {
-            "name": "table",
-            "classification": "resource"
-        },
+        "type": "table",
         "records": [{
             "urn": "bigquery::gcpproject/dataset/tablename-1",
             "name": "tablename-1",

--- a/store/elasticsearch/testdata/search-test-fixture.json
+++ b/store/elasticsearch/testdata/search-test-fixture.json
@@ -1,6 +1,8 @@
-[{
+[
+    {
         "type": "topic",
-        "records": [{
+        "records": [
+            {
                 "urn": "order-topic",
                 "name": "order-topic",
                 "service": "kafka",
@@ -59,7 +61,8 @@
     },
     {
         "type": "table",
-        "records": [{
+        "records": [
+            {
                 "urn": "au2-microsoft-invoice",
                 "name": "microsoft-invoice",
                 "service": "postgres",
@@ -73,9 +76,17 @@
                     "description": "Transaction records for every microsoft purchase",
                     "total_rows": 100,
                     "schema": [
-                        { "name": "id" },
-                        { "name": "username", "description": "purchaser username" },
-                        { "name": "item_id", "description": "item identifications" }
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "username",
+                            "description": "purchaser username"
+                        },
+                        {
+                            "name": "item_id",
+                            "description": "item identifications"
+                        }
                     ]
                 }
             },
@@ -93,136 +104,150 @@
                     "description": "Transaction records for every Apple purchase",
                     "total_rows": 100,
                     "schema": [
-                        { "name": "id" },
-                        { "name": "user_id", "description": "purchaser user idenfitication" },
-                        { "name": "item_id", "description": "item identifications" }
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "user_id",
+                            "description": "purchaser user idenfitication"
+                        },
+                        {
+                            "name": "item_id",
+                            "description": "item identifications"
+                        }
                     ]
+                }
+            },
+            {
+                "urn": "bigquery::gcpproject/dataset/tablename-1",
+                "name": "tablename-1",
+                "service": "bigquery",
+                "description": "A sample of table record",
+                "data": {
+                    "preview": {},
+                    "profile": {
+                        "common_join": [
+                            {
+                                "conditions": [
+                                    "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
+                                ],
+                                "count": 1,
+                                "urn": "bigquery::gcpproject/dataset/tablename-mid"
+                            }
+                        ],
+                        "filter_conditions": [
+                            "WHERE t.column_5 = 'success' AND t.item_id = \"280481a2-2384-4b81-aa3e-214ac60b31db\" AND event_timestamp >= TIMESTAMP(\"2021-10-29\", \"UTC\") AND event_timestamp < TIMESTAMP(\"2021-11-22T02:01:06Z\")"
+                        ],
+                        "usage_count": 1
+                    },
+                    "properties": {
+                        "attributes": {
+                            "dataset": "dataset",
+                            "full_qualified_name": "gcpproject:dataset.tablename-1",
+                            "partition_field": "event_timestamp",
+                            "project": "gcpproject",
+                            "type": "TABLE"
+                        },
+                        "labels": {
+                            "owner": "user_1"
+                        }
+                    },
+                    "resource": {
+                        "name": "tablename-1",
+                        "service": "bigquery",
+                        "urn": "bigquery::gcpproject/dataset/tablename-1"
+                    }
+                }
+            },
+            {
+                "urn": "bigquery::gcpproject/dataset/tablename-common",
+                "name": "tablename-common",
+                "service": "bigquery",
+                "description": "A sample of table record with high usage",
+                "data": {
+                    "preview": {},
+                    "profile": {
+                        "common_join": [
+                            {
+                                "conditions": [
+                                    "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
+                                ],
+                                "count": 1,
+                                "urn": "bigquery::gcpproject/dataset/tablename-mid"
+                            }
+                        ],
+                        "filter_conditions": [
+                            "WHERE t.column_5 = 'success' AND t.item_id = \"280481a2-2384-4b81-aa3e-214ac60b31db\" AND event_timestamp >= TIMESTAMP(\"2021-10-29\", \"UTC\") AND event_timestamp < TIMESTAMP(\"2021-11-22T02:01:06Z\")"
+                        ],
+                        "usage_count": 10
+                    },
+                    "properties": {
+                        "attributes": {
+                            "dataset": "dataset",
+                            "full_qualified_name": "gcpproject:dataset.tablename-common",
+                            "partition_field": "event_timestamp",
+                            "project": "gcpproject",
+                            "type": "TABLE"
+                        },
+                        "labels": {
+                            "owner": "user_1"
+                        }
+                    },
+                    "resource": {
+                        "name": "tablename-common",
+                        "service": "bigquery",
+                        "urn": "bigquery::gcpproject/dataset/tablename-common"
+                    }
+                }
+            },
+            {
+                "urn": "bigquery::gcpproject/dataset/tablename-mid",
+                "name": "tablename-mid",
+                "service": "bigquery",
+                "description": "A sample of table record with mid usage",
+                "data": {
+                    "preview": {},
+                    "profile": {
+                        "common_join": [
+                            {
+                                "conditions": [
+                                    "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
+                                ],
+                                "count": 1,
+                                "urn": "bigquery::gcpproject/dataset/tablename-high"
+                            },
+                            {
+                                "conditions": [
+                                    "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
+                                ],
+                                "count": 1,
+                                "urn": "bigquery::gcpproject/dataset/tablename-1"
+                            }
+                        ],
+                        "filter_conditions": [
+                            "WHERE t.column_5 = 'success' AND t.item_id = \"280481a2-2384-4b81-aa3e-214ac60b31db\" AND event_timestamp >= TIMESTAMP(\"2021-10-29\", \"UTC\") AND event_timestamp < TIMESTAMP(\"2021-11-22T02:01:06Z\")"
+                        ],
+                        "usage_count": 5
+                    },
+                    "properties": {
+                        "attributes": {
+                            "dataset": "dataset",
+                            "full_qualified_name": "gcpproject:dataset.tablename-mid",
+                            "partition_field": "event_timestamp",
+                            "project": "gcpproject",
+                            "type": "TABLE"
+                        },
+                        "labels": {
+                            "owner": "user_1"
+                        }
+                    },
+                    "resource": {
+                        "name": "tablename-mid",
+                        "service": "bigquery",
+                        "urn": "bigquery::gcpproject/dataset/tablename-mid"
+                    }
                 }
             }
         ]
-    },
-    {
-        "type": "table",
-        "records": [{
-            "urn": "bigquery::gcpproject/dataset/tablename-1",
-            "name": "tablename-1",
-            "service": "bigquery",
-            "description": "A sample of table record",
-            "data": {
-                "preview": {},
-                "profile": {
-                    "common_join": [{
-                        "conditions": [
-                            "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
-                        ],
-                        "count": 1,
-                        "urn": "bigquery::gcpproject/dataset/tablename-mid"
-                    }],
-                    "filter_conditions": [
-                        "WHERE t.column_5 = 'success' AND t.item_id = \"280481a2-2384-4b81-aa3e-214ac60b31db\" AND event_timestamp >= TIMESTAMP(\"2021-10-29\", \"UTC\") AND event_timestamp < TIMESTAMP(\"2021-11-22T02:01:06Z\")"
-                    ],
-                    "usage_count": 1
-                },
-                "properties": {
-                    "attributes": {
-                        "dataset": "dataset",
-                        "full_qualified_name": "gcpproject:dataset.tablename-1",
-                        "partition_field": "event_timestamp",
-                        "project": "gcpproject",
-                        "type": "TABLE"
-                    },
-                    "labels": {
-                        "owner": "user_1"
-                    }
-                },
-                "resource": {
-                    "name": "tablename-1",
-                    "service": "bigquery",
-                    "urn": "bigquery::gcpproject/dataset/tablename-1"
-                }
-            }
-        }, {
-            "urn": "bigquery::gcpproject/dataset/tablename-common",
-            "name": "tablename-common",
-            "service": "bigquery",
-            "description": "A sample of table record with high usage",
-            "data": {
-                "preview": {},
-                "profile": {
-                    "common_join": [{
-                        "conditions": [
-                            "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
-                        ],
-                        "count": 1,
-                        "urn": "bigquery::gcpproject/dataset/tablename-mid"
-                    }],
-                    "filter_conditions": [
-                        "WHERE t.column_5 = 'success' AND t.item_id = \"280481a2-2384-4b81-aa3e-214ac60b31db\" AND event_timestamp >= TIMESTAMP(\"2021-10-29\", \"UTC\") AND event_timestamp < TIMESTAMP(\"2021-11-22T02:01:06Z\")"
-                    ],
-                    "usage_count": 10
-                },
-                "properties": {
-                    "attributes": {
-                        "dataset": "dataset",
-                        "full_qualified_name": "gcpproject:dataset.tablename-common",
-                        "partition_field": "event_timestamp",
-                        "project": "gcpproject",
-                        "type": "TABLE"
-                    },
-                    "labels": {
-                        "owner": "user_1"
-                    }
-                },
-                "resource": {
-                    "name": "tablename-common",
-                    "service": "bigquery",
-                    "urn": "bigquery::gcpproject/dataset/tablename-common"
-                }
-            }
-        }, {
-            "urn": "bigquery::gcpproject/dataset/tablename-mid",
-            "name": "tablename-mid",
-            "service": "bigquery",
-            "description": "A sample of table record with mid usage",
-            "data": {
-                "preview": {},
-                "profile": {
-                    "common_join": [{
-                        "conditions": [
-                            "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
-                        ],
-                        "count": 1,
-                        "urn": "bigquery::gcpproject/dataset/tablename-high"
-                    }, {
-                        "conditions": [
-                            "ON target.column_1 = source.column_1 and target.column_3 = source.column_3 and DATE(target.event_timestamp) = DATE(source.event_timestamp)"
-                        ],
-                        "count": 1,
-                        "urn": "bigquery::gcpproject/dataset/tablename-1"
-                    }],
-                    "filter_conditions": [
-                        "WHERE t.column_5 = 'success' AND t.item_id = \"280481a2-2384-4b81-aa3e-214ac60b31db\" AND event_timestamp >= TIMESTAMP(\"2021-10-29\", \"UTC\") AND event_timestamp < TIMESTAMP(\"2021-11-22T02:01:06Z\")"
-                    ],
-                    "usage_count": 5
-                },
-                "properties": {
-                    "attributes": {
-                        "dataset": "dataset",
-                        "full_qualified_name": "gcpproject:dataset.tablename-mid",
-                        "partition_field": "event_timestamp",
-                        "project": "gcpproject",
-                        "type": "TABLE"
-                    },
-                    "labels": {
-                        "owner": "user_1"
-                    }
-                },
-                "resource": {
-                    "name": "tablename-mid",
-                    "service": "bigquery",
-                    "urn": "bigquery::gcpproject/dataset/tablename-mid"
-                }
-            }
-        }]
     }
 ]

--- a/store/elasticsearch/testutil/elastic_search.go
+++ b/store/elasticsearch/testutil/elastic_search.go
@@ -94,6 +94,12 @@ func NewElasticsearchTestServer() *ElasticsearchTestServer {
 			Addresses: []string{
 				server.url.String(),
 			},
+			// uncomment below code to debug request and response to elasticsearch
+			// Logger: &estransport.ColorLogger{
+			// 	Output:             os.Stdout,
+			// 	EnableRequestBody:  true,
+			// 	EnableResponseBody: true,
+			// },
 		},
 	)
 	if err != nil {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -272,6 +272,10 @@ paths:
           name: "filter.type"
           type: string
           description: 'restrict results to the specified types (as in a Columbus type, for instance "dagger", or "firehose")'
+        - in: query
+          name: "sortby"
+          type: string
+          description: 'descendingly sort based on a numeric field in the record. the nested field is written with period separated field name. eg, "data.profile.usage_count"'
       responses:
         200:
           description: OK

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+swagger: "2.0"
 info:
   title: "Data Discovery and Lineage Service"
   description: "Data Discovery and Lineage Service"
@@ -23,11 +23,11 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/AdjacencyMap'
+            $ref: "#/definitions/AdjacencyMap"
         404:
           description: record not found
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   "/v1/lineage/{type}/{record}":
     get:
       tags:
@@ -44,11 +44,11 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/AdjacencyMap'
+            $ref: "#/definitions/AdjacencyMap"
         404:
           description: invalid type requested
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   "/v1/types":
     get:
       tags:
@@ -63,7 +63,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Type'
+              $ref: "#/definitions/Type"
     put:
       tags:
         - Type
@@ -74,17 +74,17 @@ paths:
       parameters:
         - in: body
           name: ""
-          schema: 
+          schema:
             $ref: "#/definitions/Type"
       responses:
         201:
           description: OK
           schema:
-            $ref: '#/definitions/Type'
+            $ref: "#/definitions/Type"
         400:
           description: invalid type
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   "/v1/types/{name}":
     put:
       tags:
@@ -103,16 +103,16 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Record'
+              $ref: "#/definitions/Record"
       responses:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/Status'
+            $ref: "#/definitions/Status"
         400:
           description: validation error
           schema:
-            $ref: '#/definitions/ValidationError'
+            $ref: "#/definitions/ValidationError"
     delete:
       tags:
         - Type
@@ -134,7 +134,7 @@ paths:
         422:
           description: reserved type name error
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   "/v1/types/{name}/details":
     get:
       tags:
@@ -147,11 +147,11 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/Type'
+            $ref: "#/definitions/Type"
         404:
           description: type not found
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   "/v1/types/{name}/records":
     get:
       tags:
@@ -178,15 +178,15 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Record'
+              $ref: "#/definitions/Record"
         400:
           description: bad input
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
         404:
           description: not found
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   "/v1/types/{name}/records/{id}":
     delete:
       tags:
@@ -212,7 +212,7 @@ paths:
         404:
           description: type or record cannot be found
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   "/v1/types/{name}/{id}":
     get:
       tags:
@@ -233,11 +233,11 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/Record'
+            $ref: "#/definitions/Record"
         404:
           description: document or type does not exist
           schema:
-            $ref: '#/definitions/Error'     
+            $ref: "#/definitions/Error"
   "/v1/search":
     get:
       tags:
@@ -273,7 +273,7 @@ paths:
           type: string
           description: 'restrict results to the specified types (as in a Columbus type, for instance "dagger", or "firehose")'
         - in: query
-          name: "sortby"
+          name: "rankby"
           type: string
           description: 'descendingly sort based on a numeric field in the record. the nested field is written with period separated field name. eg, "data.profile.usage_count"'
       responses:
@@ -311,19 +311,19 @@ paths:
         201:
           description: OK
           schema:
-            $ref: '#/definitions/Tag'
+            $ref: "#/definitions/Tag"
         400:
           description: validation error
           schema:
-            $ref: '#/definitions/ValidationError'
+            $ref: "#/definitions/ValidationError"
         409:
           description: duplicate tags
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
         500:
           description: internal server error
           schema:
-            $ref: '#/definitions/Error'        
+            $ref: "#/definitions/Error"
   "/v1/tags/templates":
     get:
       tags:
@@ -338,11 +338,11 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/TagTemplate'
+              $ref: "#/definitions/TagTemplate"
         500:
           description: internal server error
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
     post:
       tags:
         - Tag
@@ -365,19 +365,19 @@ paths:
         201:
           description: Created
           schema:
-            $ref: '#/definitions/TagTemplate'
+            $ref: "#/definitions/TagTemplate"
         400:
           description: validation error
           schema:
-            $ref: '#/definitions/ValidationError'
+            $ref: "#/definitions/ValidationError"
         409:
           description: duplicate template
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
         500:
           description: internal server error
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   "/v1/tags/templates/{template_urn}":
     get:
       tags:
@@ -395,15 +395,15 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/TagTemplate'
+            $ref: "#/definitions/TagTemplate"
         404:
           description: template not found
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
         500:
           description: internal server error
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
     put:
       tags:
         - Tag
@@ -429,19 +429,19 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/TagTemplate'
+            $ref: "#/definitions/TagTemplate"
         400:
           description: validation error
           schema:
-            $ref: '#/definitions/ValidationError'
+            $ref: "#/definitions/ValidationError"
         404:
           description: template not found
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
         500:
           description: internal server error
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
     delete:
       tags:
         - Tag
@@ -463,11 +463,11 @@ paths:
         404:
           description: template not found
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
         500:
           description: internal server error
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   "/v1/tags/types/{type}/records/{record_urn}":
     get:
       tags:
@@ -491,11 +491,11 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Tag'
+              $ref: "#/definitions/Tag"
         500:
           description: internal server error
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
   "/v1/tags/types/{type}/records/{record_urn}/templates/{template_urn}":
     get:
       tags:
@@ -521,15 +521,15 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/Tag'
+            $ref: "#/definitions/Tag"
         404:
           description: record is not found
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
         500:
           description: internal server error
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
     put:
       tags:
         - Tag
@@ -562,19 +562,19 @@ paths:
         201:
           description: OK
           schema:
-            $ref: '#/definitions/Tag'
+            $ref: "#/definitions/Tag"
         400:
           description: validation error
           schema:
-            $ref: '#/definitions/ValidationError'
+            $ref: "#/definitions/ValidationError"
         404:
           description: tag is not found
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
         500:
           description: internal server error
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
     delete:
       tags:
         - Tag
@@ -601,15 +601,15 @@ paths:
         400:
           description: template_urn is required
           schema:
-            $ref: '#/definitions/ValidationError'
+            $ref: "#/definitions/ValidationError"
         404:
           description: record is not found
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
         500:
           description: internal server error
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
 definitions:
   Classifications: &CLASSIFICATIONS
     type: string
@@ -640,9 +640,9 @@ definitions:
         type: object
         description: "map of string"
       upstreams:
-        $ref: '#/definitions/LineageRecord'
+        $ref: "#/definitions/LineageRecord"
       downstreams:
-        $ref: '#/definitions/LineageRecord'
+        $ref: "#/definitions/LineageRecord"
       created_at:
         type: string
       updated_at:
@@ -658,12 +658,12 @@ definitions:
         type: string
       tag_values:
         type: array
-        items: 
+        items:
           type: object
           required:
             - field_id
             - field_value
-          properties: 
+          properties:
             field_id:
               type: number
             field_value:
@@ -678,7 +678,7 @@ definitions:
               type: string
             field_options:
               type: array
-              items: 
+              items:
                 type: string
             field_required:
               type: boolean
@@ -708,7 +708,7 @@ definitions:
             - display_name
             - description
             - data_type
-          properties: 
+          properties:
             id:
               type: number
             urn:
@@ -727,7 +727,7 @@ definitions:
                 - datetime
             options:
               type: array
-              items: 
+              items:
                 type: string
             required:
               type: boolean
@@ -747,7 +747,7 @@ definitions:
         default: success
   LineageRecord:
     type: object
-    properties: 
+    properties:
       urn:
         type: string
         example: "sample-urn"
@@ -762,7 +762,7 @@ definitions:
         type: string
       type:
         type: string
-      downstreams: 
+      downstreams:
         type: array
         items:
           type: string
@@ -774,7 +774,7 @@ definitions:
     type: object
     properties:
       "<NodeLabel>":
-        $ref: '#/definitions/AdjacencyEntry'
+        $ref: "#/definitions/AdjacencyEntry"
   Type:
     type: object
     properties:
@@ -785,7 +785,7 @@ definitions:
         <<: *CLASSIFICATIONS
       record_attributes:
         type: object
-        description: defines metadata for the documents that belong to this type. All properties under record_attributes define(s) a mapping of logical purpose, to the name of the key(s) in the documents that hold those information 
+        description: defines metadata for the documents that belong to this type. All properties under record_attributes define(s) a mapping of logical purpose, to the name of the key(s) in the documents that hold those information
         properties:
           id:
             type: string
@@ -825,7 +825,7 @@ definitions:
         description: "key value pairs describing the labels configured for the given type of record. Example of labels: team, created, owner etc"
   ValidationError:
     allOf:
-      - $ref: '#/definitions/Error'
+      - $ref: "#/definitions/Error"
       - type: object
         properties:
           details:


### PR DESCRIPTION
Changes
- Add a new query param `sortby` in the API that accepts `usage` (only for now). If this is passed, we return search results that sorted by table usage (the bigger usage_count, the more it prioritized to appear first)
- Convert ES query
From this
```
{
	"query": {
		"bool": {
			"should": [
				{
					"multi_match": {
						"fields": [
							"urn^10",
							"name^5"
						],
						"query": "sample"
					}
				},
				{
					"multi_match": {
						"fields": [
							"urn^10",
							"name^5"
						],
						"fuzziness": "AUTO",
						"query": "sample"
					}
				},
				{
					"multi_match": {
						"fuzziness": "AUTO",
						"query": "sample"
					}
				}
			]
		}
	},
	"min_score": 0.01
}
```

To use `function score query`
```
{
	"query": {
		"function_score": {
			"functions": [
				{
					"field_value_factor": {
						"field": "data.profile.usage_count",
						"missing": 1,
						"modifier": "log1p"
					},
					"weight": 1
				}
			],
			"query": {
				"bool": {
					"should": [
						{
							"multi_match": {
								"fields": [
									"urn^10",
									"name^5"
								],
								"query": "sample"
							}
						},
						{
							"multi_match": {
								"fields": [
									"urn^10",
									"name^5"
								],
								"fuzziness": "AUTO",
								"query": "sample"
							}
						},
						{
							"multi_match": {
								"fuzziness": "AUTO",
								"query": "sample"
							}
						}
					]
				}
			},
			"score_mode": "sum"
		}
	},
	"min_score": 0.01
}
```