### PR TITLE
fix: double lint check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: lint
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   golangci:


### PR DESCRIPTION
### Problem
`lint` action is being run twice whenever there is a push on pull request.

### Root cause
It is because we set it to run with below config
```
on: [push, pull_request]
```

### Solution
Remove `pull_request` as it is already included when pushing.