### PR TITLE
close es test container after tests

### DIFF
--- a/store/elasticsearch/init_test.go
+++ b/store/elasticsearch/init_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
@@ -20,8 +21,13 @@ func TestMain(m *testing.M) {
 	// an elasticsearch server. That means you can't run unit tests
 	// standlone :/
 	esTestServer = testutil.NewElasticsearchTestServer()
-	defer esTestServer.Close()
-	os.Exit(m.Run())
+	exitCode := m.Run()
+
+	if err := esTestServer.Close(); err != nil {
+		fmt.Println("Error closing elasticsearch test server:", err)
+		return
+	}
+	os.Exit(exitCode)
 }
 
 // name this somethings that's more generic

--- a/store/elasticsearch/testutil/elastic_search.go
+++ b/store/elasticsearch/testutil/elastic_search.go
@@ -14,8 +14,7 @@ import (
 
 var (
 	elasticSearchCmdLine = []string{
-		"docker", "run", "-d", "-P", "-e", "discovery.type=single-node",
-		"elasticsearch:7.6.1",
+		"docker", "run", "-d", "-P", "-e", "discovery.type=single-node", "elasticsearch:7.6.1",
 	}
 	// "9200/tcp" refers to the default container port where elasticsearch server runs
 	esHostQuery = `{{index .NetworkSettings.Ports "9200/tcp" 0 "HostIp"}}:{{index .NetworkSettings.Ports "9200/tcp" 0 "HostPort"}}`

--- a/store/elasticsearch/testutil/elastic_search.go
+++ b/store/elasticsearch/testutil/elastic_search.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	elasticSearchCmdLine = []string{
-		"docker", "run", "-d", "-P", "-e", "discovery.type=single-node", "elasticsearch:7.6.1",
+		"docker", "run", "-d", "-P", "--rm", "-e", "discovery.type=single-node", "elasticsearch:7.6.1",
 	}
 	// "9200/tcp" refers to the default container port where elasticsearch server runs
 	esHostQuery = `{{index .NetworkSettings.Ports "9200/tcp" 0 "HostIp"}}:{{index .NetworkSettings.Ports "9200/tcp" 0 "HostPort"}}`


### PR DESCRIPTION
The `os.Exit` makes the function exit before even running the defer call., due to which the es container is left running as it is to be cleaned up manually. This change fixes it and the container is cleaned up on stop.

Fixes: #71 